### PR TITLE
feature/order-add-payment-terms-to-order

### DIFF
--- a/order.go
+++ b/order.go
@@ -291,16 +291,16 @@ type PaymentTerms struct {
 	Currency         string            `json:"currency,omitempty"`
 	PaymentTermsName string            `json:"payment_terms_name,omitempty"`
 	PaymentTermsType string            `json:"payment_terms_type,omitempty"`
-	DueInDays        int               `json:"due_in_days,omitempty"`
+	DueInDays        int64             `json:"due_in_days,omitempty"`
 	PaymentSchedules []PaymentSchedule `json:"payment_schedules,omitempty"`
 }
 
 type PaymentSchedule struct {
 	Amount                *decimal.Decimal `json:"amount,omitempty"`
 	Currency              string           `json:"currency,omitempty"`
-	IssuedAt              string           `json:"issued_at,omitempty"`
-	DueAt                 string           `json:"due_at,omitempty"`
-	CompletedAt           string           `json:"completed_at,omitempty"`
+	IssuedAt              *time.Time       `json:"issued_at,omitempty"`
+	DueAt                 *time.Time       `json:"due_at,omitempty"`
+	CompletedAt           *time.Time       `json:"completed_at,omitempty"`
 	ExpectedPaymentMethod string           `json:"expected_payment_method,omitempty"`
 }
 

--- a/order.go
+++ b/order.go
@@ -291,7 +291,7 @@ type PaymentTerms struct {
 	Currency         string            `json:"currency,omitempty"`
 	PaymentTermsName string            `json:"payment_terms_name,omitempty"`
 	PaymentTermsType string            `json:"payment_terms_type,omitempty"`
-	DueInDays        string            `json:"due_in_days,omitempty"`
+	DueInDays        int               `json:"due_in_days,omitempty"`
 	PaymentSchedules []PaymentSchedule `json:"payment_schedules,omitempty"`
 }
 

--- a/order.go
+++ b/order.go
@@ -116,6 +116,7 @@ type Order struct {
 	Tags                  string           `json:"tags,omitempty"`
 	LocationId            int64            `json:"location_id,omitempty"`
 	PaymentGatewayNames   []string         `json:"payment_gateway_names,omitempty"`
+	PaymentTerms          *PaymentTerms    `json:"payment_terms,omitempty"`
 	ProcessingMethod      string           `json:"processing_method,omitempty"`
 	Refunds               []Refund         `json:"refunds,omitempty"`
 	UserId                int64            `json:"user_id,omitempty"`
@@ -283,6 +284,24 @@ type RefundLineItem struct {
 	LineItem   *LineItem        `json:"line_item,omitempty"`
 	Subtotal   *decimal.Decimal `json:"subtotal,omitempty"`
 	TotalTax   *decimal.Decimal `json:"total_tax,omitempty"`
+}
+
+type PaymentTerms struct {
+	Amount           *decimal.Decimal  `json:"amount,omitempty"`
+	Currency         string            `json:"currency,omitempty"`
+	PaymentTermsName string            `json:"payment_terms_name,omitempty"`
+	PaymentTermsType string            `json:"payment_terms_type,omitempty"`
+	DueInDays        string            `json:"due_in_days,omitempty"`
+	PaymentSchedules []PaymentSchedule `json:"payment_schedules,omitempty"`
+}
+
+type PaymentSchedule struct {
+	Amount                *decimal.Decimal `json:"amount,omitempty"`
+	Currency              string           `json:"currency,omitempty"`
+	IssuedAt              string           `json:"issued_at,omitempty"`
+	DueAt                 string           `json:"due_at,omitempty"`
+	CompletedAt           string           `json:"completed_at,omitempty"`
+	ExpectedPaymentMethod string           `json:"expected_payment_method,omitempty"`
 }
 
 // List orders


### PR DESCRIPTION
- add payment terms to order.go. See the [doc](https://shopify.dev/docs/api/admin-rest/2024-04/resources/order#resource-object).

![image](https://github.com/bigbluedisco/go-shopify/assets/155474201/1db23029-37c2-4d3d-a272-b7e4127f9e63)
