### PR TITLE
feature/order-add-duties-for-customs

### DIFF
--- a/order.go
+++ b/order.go
@@ -253,7 +253,7 @@ const (
 
 // Order represents a Shopify order
 type Order struct {
-  Id                       uint64                  `json:"id,omitempty"`
+	Id                       uint64                  `json:"id,omitempty"`
 	Name                     string                  `json:"name,omitempty"`
 	Email                    string                  `json:"email,omitempty"`
 	CreatedAt                *time.Time              `json:"created_at,omitempty"`
@@ -282,6 +282,7 @@ type Order struct {
 	CurrentTotalTax          *decimal.Decimal        `json:"current_total_tax,omitempty"`
 	CurrentTotalTaxSet       *AmountSet              `json:"current_total_tax_set,omitempty"`
 	TaxLines                 []TaxLine               `json:"tax_lines,omitempty"`
+	CurrentTotalDutiesSet    *AmountSet              `json:"current_total_duties_set,omitempty"`
 	TotalWeight              int                     `json:"total_weight,omitempty"`
 	FinancialStatus          orderFinancialStatus    `json:"financial_status,omitempty"`
 	Fulfillments             []Fulfillment           `json:"fulfillments,omitempty"`
@@ -310,7 +311,7 @@ type Order struct {
 	Tags                     string                  `json:"tags,omitempty"`
 	LocationId               uint64                  `json:"location_id,omitempty"`
 	PaymentGatewayNames      []string                `json:"payment_gateway_names,omitempty"`
-  PaymentTerms             *PaymentTerms    `json:"payment_terms,omitempty"`
+	PaymentTerms             *PaymentTerms           `json:"payment_terms,omitempty"`
 	ProcessingMethod         string                  `json:"processing_method,omitempty"`
 	Refunds                  []Refund                `json:"refunds,omitempty"`
 	UserId                   uint64                  `json:"user_id,omitempty"`
@@ -640,7 +641,6 @@ func (s *OrderServiceOp) ListAll(ctx context.Context, options interface{}) ([]Or
 
 	for {
 		entities, pagination, err := s.ListWithPagination(ctx, options)
-
 		if err != nil {
 			return collector, err
 		}


### PR DESCRIPTION
# Description
Add the `current_total_duties_set`  field on the order ([shopify documentation](https://shopify.dev/docs/api/admin-rest/2024-04/resources/order#:~:text=current_total_duties_set))

The final goal is to store the duties paid by the buyer and display them on the merchant app order page.